### PR TITLE
Update version string to 1.1

### DIFF
--- a/BCN3DR_v1_1/ultralcd.cpp
+++ b/BCN3DR_v1_1/ultralcd.cpp
@@ -1135,7 +1135,7 @@ void lcd_init()
 	lcd.setCursor(6,2);
 	lcd.print("RepRapBCN");
 	lcd.setCursor(8,3);
-	lcd.print("v1.0");
+	lcd.print("v1.1");
 
 #ifdef NEWPANEL
     pinMode(BTN_EN1,INPUT);


### PR DESCRIPTION
After updating the firmware via Arduino on a Mac, the LCD on the BCN3DR still shows "1.0".
We tested that the LCD shows "1.1" when starting.
